### PR TITLE
docs: correct tests directory position in README directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ KOCO-bench/
 │   │   │   ├── test_examples/          # Test projects
 │   │   │   │   └── {example}/          # Individual test cases
 │   │   │   │       ├── code/           # Project code
-│   │   │   │       ├── tests/          # Test suites
+│   │   │   │       │   └── tests/      # Test suites
 │   │   │   │       └── requirements/   # Task specifications
 │   │   │   └── README.md
 │   │   └── scripts/                    # Evaluation scripts


### PR DESCRIPTION
The tests/ directory was incorrectly shown as a sibling of code/ in README. It should instead be a subdirectory of code/ according to the actual project structure.