### PR TITLE
fix(tensorrt): remove redundant skipIf and defensive imports in byteperf tests

### DIFF
--- a/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_loss_balancer.py
+++ b/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_loss_balancer.py
@@ -23,15 +23,9 @@ MinimalMock.setup_megatron_mocks()
 # Use insert(0) instead of append to avoid being overridden by installed megatron package
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'byte_train_perf', 'Megatron-LM'))
 
-# Defensive import
-try:
-    from megatron.inference.algos.distillation import LogitsAndIntermediatesLossBalancer
-    import modelopt.torch.distill as mtd
-    from modelopt.torch.distill import DistillationLossBalancer
-    IMPORT_SUCCESS = True
-except Exception as e:
-    print(f"Warning: Unable to import implementation code: {e}")
-    IMPORT_SUCCESS = False
+from megatron.inference.algos.distillation import LogitsAndIntermediatesLossBalancer
+import modelopt.torch.distill as mtd
+from modelopt.torch.distill import DistillationLossBalancer
 
 
 class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
@@ -41,7 +35,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         """Set up test environment"""
         torch.manual_seed(42)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_init_default_params(self):
         """
         Testcase1: Default parameter initialization
@@ -54,7 +47,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         self.assertEqual(balancer._kd_loss_scale, 1.0)
         self.assertEqual(balancer._skip_original_loss, False)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_init_custom_params(self):
         """
         Testcase2: Custom parameter initialization
@@ -67,7 +59,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         self.assertEqual(balancer._kd_loss_scale, 2.0)
         self.assertEqual(balancer._skip_original_loss, True)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_forward_with_intermediate_loss(self):
         """
         Testcase3: Forward pass with intermediate loss
@@ -109,7 +100,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(4.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_forward_without_intermediate_loss(self):
         """
         Testcase4: Forward pass without intermediate loss
@@ -138,7 +128,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(4.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_forward_skip_original_loss(self):
         """
         Testcase5: Skip original loss
@@ -171,7 +160,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(2.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_forward_dynamic_scaling(self):
         """
         Testcase6: Dynamic scaling computation
@@ -204,7 +192,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(6.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_forward_specific_values(self):
         """
         Testcase7: Specific value verification
@@ -233,7 +220,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(10.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_intermediate_loss_zero(self):
         """
         Testcase8: Intermediate loss is zero
@@ -258,7 +244,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(4.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_loss_dict_modification(self):
         """
         Testcase9: Verifyloss_dict is correctly modified
@@ -285,7 +270,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         self.assertIn("LogitsKLLoss", loss_dict)
         self.assertIn("intermediate_loss", loss_dict)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_gradient_flow(self):
         """
         Testcase10: VerifyGradient flow
@@ -312,7 +296,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         # Verify gradients are computed
         self.assertTrue(loss_dict["LogitsKLLoss"].grad is not None)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_multiple_intermediate_losses(self):
         """
         Testcase11: Multiple intermediate losses
@@ -341,7 +324,6 @@ class TestLogitsAndIntermediatesLossBalancer(unittest.TestCase):
         expected_loss = torch.tensor(6.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_different_kd_loss_scales(self):
         """
         Testcase12: Different kd_loss_scale values
@@ -377,7 +359,6 @@ class TestLossBalancerEdgeCases(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(42)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_only_logits_loss(self):
         """
         Testcase13: Only logits loss, no intermediate loss
@@ -401,7 +382,6 @@ class TestLossBalancerEdgeCases(unittest.TestCase):
         expected_loss = torch.tensor(6.0)
         torch.testing.assert_close(result, expected_loss, atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_small_values(self):
         """
         Testcase14: Very small loss values
@@ -424,7 +404,6 @@ class TestLossBalancerEdgeCases(unittest.TestCase):
         self.assertFalse(torch.isinf(result))
         self.assertTrue(result.item() > 0)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_large_values(self):
         """
         Testcase15: Very large loss values

--- a/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_loss_func.py
+++ b/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_loss_func.py
@@ -22,13 +22,7 @@ MinimalMock.setup_megatron_mocks()
 # Add the parent directory to sys.path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'byte_train_perf', 'Megatron-LM'))
 
-# Defensive import
-try:
-    from megatron.inference.gpt.loss_func import loss_func
-    IMPORT_SUCCESS = True
-except Exception as e:
-    print(f"Warning: Unable to import implementation code: {e}")
-    IMPORT_SUCCESS = False
+from megatron.inference.gpt.loss_func import loss_func
 
 
 class TestLossFunc(unittest.TestCase):
@@ -60,7 +54,6 @@ class TestLossFunc(unittest.TestCase):
         
         return model
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -110,7 +103,6 @@ class TestLossFunc(unittest.TestCase):
         # Verify return value
         torch.testing.assert_close(loss, torch.tensor(2.5), atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -156,7 +148,6 @@ class TestLossFunc(unittest.TestCase):
         # Verify through model's mock
         self.assertTrue(model._enable_kd)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -191,7 +182,6 @@ class TestLossFunc(unittest.TestCase):
         self.assertIn('lm loss', report)
         torch.testing.assert_close(loss, torch.tensor(1.5), atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -225,7 +215,6 @@ class TestLossFunc(unittest.TestCase):
         self.assertIn('lm loss', report)
         torch.testing.assert_close(loss, torch.tensor(1.8), atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -255,7 +244,6 @@ class TestLossFunc(unittest.TestCase):
         call_args = mock_mask.call_args
         self.assertEqual(call_args[0][1].shape, loss_mask.shape)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -285,7 +273,6 @@ class TestLossFunc(unittest.TestCase):
                 
                 torch.testing.assert_close(loss, torch.tensor(loss_val), atol=1e-4, rtol=1e-4)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -332,7 +319,6 @@ class TestLossFuncEdgeCases(unittest.TestCase):
         self.mock_args.export_kd_teacher_load = None
         self.mock_args.export_kd_finalize = False
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -361,7 +347,6 @@ class TestLossFuncEdgeCases(unittest.TestCase):
         self.assertTrue(isinstance(loss, torch.Tensor))
         self.assertIn('lm loss', report)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')
@@ -390,7 +375,6 @@ class TestLossFuncEdgeCases(unittest.TestCase):
         self.assertTrue(isinstance(loss, torch.Tensor))
         self.assertIn('lm loss', report)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.loss_func.get_args')
     @patch('megatron.inference.gpt.loss_func.unwrap_model')
     @patch('megatron.inference.gpt.loss_func._mask_loss')

--- a/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_mcore_distillation_adjust.py
+++ b/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_mcore_distillation_adjust.py
@@ -23,14 +23,8 @@ MinimalMock.setup_megatron_mocks()
 # Add the parent directory to sys.path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'byte_train_perf', 'Megatron-LM'))
 
-# Defensive import
-try:
-    from megatron.inference.algos.distillation import adjust_distillation_model_for_mcore
-    import modelopt.torch.distill as mtd
-    IMPORT_SUCCESS = True
-except Exception as e:
-    print(f"Warning: Unable to import implementation code: {e}")
-    IMPORT_SUCCESS = False
+from megatron.inference.algos.distillation import adjust_distillation_model_for_mcore
+import modelopt.torch.distill as mtd
 
 
 class TestAdjustDistillationModelForMCore(unittest.TestCase):
@@ -71,7 +65,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         
         return model
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_sharded_state_dict_wrapping(self):
         """
         Testcase1: sharded_state_dict method correctly wrapped
@@ -96,7 +89,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         # Verify: New method is types.MethodType
         self.assertIsInstance(model.sharded_state_dict, types.MethodType)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_skip_lm_loss_when_enabled(self):
         """
         Testcase2: When skip_lm_loss=True, training mode returns zero loss
@@ -129,7 +121,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         expected_zeros = torch.zeros_like(labels)
         torch.testing.assert_close(loss, expected_zeros, atol=1e-6, rtol=1e-6)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_skip_lm_loss_eval_mode(self):
         """
         Testcase3: When skip_lm_loss=True but eval mode, still compute real loss
@@ -160,7 +151,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         self.assertTrue(isinstance(loss, torch.Tensor))
         # Since it calls the original method, should return actual CE loss
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_skip_lm_loss_disabled(self):
         """
         Testcase4: When skip_lm_loss=False, do not modify compute_language_model_loss
@@ -182,7 +172,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         # Verify: compute_language_model_loss still the original method
         # (Although there may be subtle differences in actual scenarios, the main logic should remain unchanged)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_sharded_state_dict_calls_hide_teacher(self):
         """
         Testcase5: New sharded_state_dict calls hide_teacher_model
@@ -212,7 +201,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         self.assertTrue(len(hide_called) > 0)
         self.assertTrue(isinstance(result, dict))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_method_binding(self):
         """
         Testcase6: Verify methods correctly bound to model instance
@@ -233,7 +221,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         self.assertIsInstance(model.compute_language_model_loss, types.MethodType)
         self.assertEqual(model.compute_language_model_loss.__self__, model)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_multiple_calls_idempotence(self):
         """
         Testcase7: Idempotence of multiple function calls
@@ -255,7 +242,6 @@ class TestAdjustDistillationModelForMCore(unittest.TestCase):
         self.assertTrue(callable(model.sharded_state_dict))
         self.assertTrue(hasattr(model, '_sharded_state_dict'))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_zero_loss_shape_matches_labels(self):
         """
         Testcase8: Zero tensor returned by skip_lm_loss matches labels shape
@@ -320,7 +306,6 @@ class TestAdjustDistillationEdgeCases(unittest.TestCase):
             
         return model
         
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_empty_distill_cfg(self):
         """
         Testcase9: Empty distill_cfg (only required fields)
@@ -336,7 +321,6 @@ class TestAdjustDistillationEdgeCases(unittest.TestCase):
         # Verify basic wrapping completed
         self.assertTrue(hasattr(model, '_sharded_state_dict'))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     def test_training_mode_toggle(self):
         """
         Testcase10: Training mode toggle

--- a/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_model_provider.py
+++ b/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_model_provider.py
@@ -22,13 +22,7 @@ MinimalMock.setup_megatron_mocks()
 # Add the parent directory to sys.path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'byte_train_perf', 'Megatron-LM'))
 
-# Defensive import
-try:
-    from megatron.inference.gpt.model_provider import model_provider
-    IMPORT_SUCCESS = True
-except Exception as e:
-    print(f"Warning: Unable to import implementation code: {e}")
-    IMPORT_SUCCESS = False
+from megatron.inference.gpt.model_provider import model_provider
 
 
 class TestModelProvider(unittest.TestCase):
@@ -59,7 +53,6 @@ class TestModelProvider(unittest.TestCase):
         self.mock_args.manual_gc = False
         self.mock_args.export_kd_cfg = None
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.load_modelopt_state')
@@ -129,7 +122,6 @@ class TestModelProvider(unittest.TestCase):
         # Verify: model is returned
         self.assertEqual(result, mock_model)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.load_modelopt_state')
@@ -162,7 +154,6 @@ class TestModelProvider(unittest.TestCase):
         self.assertIn("ModelOpt", str(context.exception))
         self.assertIn("MCore", str(context.exception))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.mto.restore_from_modelopt_state')
@@ -213,7 +204,6 @@ class TestModelProvider(unittest.TestCase):
         # Verify: hooks are added to restored model
         mock_add_hooks.assert_called_once_with(restored_model)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider.distillation.adjust_distillation_model_for_mcore')
     @patch('megatron.inference.gpt.model_provider.distillation.load_distillation_config')
@@ -294,7 +284,6 @@ class TestModelProvider(unittest.TestCase):
         # Verify: adjust_distillation_model_for_mcore is called
         mock_adjust.assert_called_once_with(mock_distill_model, mock_distill_cfg)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider.mtd.export')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -349,7 +338,6 @@ class TestModelProvider(unittest.TestCase):
             # Verify: Exported model is returned
             self.assertEqual(result, exported_model)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.load_modelopt_state')
@@ -394,7 +382,6 @@ class TestModelProvider(unittest.TestCase):
         # VerifyError message
         self.assertIn("manual-gc", str(context.exception))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.load_modelopt_state')
@@ -477,7 +464,6 @@ class TestModelProviderEdgeCases(unittest.TestCase):
         self.mock_args.manual_gc = False
         self.mock_args.export_kd_cfg = None
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.get_tensor_model_parallel_rank')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
     @patch('megatron.inference.gpt.model_provider.load_modelopt_state')

--- a/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_teacher_provider.py
+++ b/KOCO-bench-en/domain_code_generation/tensorrt_model_optimizer/test_examples/byteperf/code/test_code/test_teacher_provider.py
@@ -23,13 +23,7 @@ MinimalMock.setup_megatron_mocks()
 # Add the parent directory to sys.path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'byte_train_perf', 'Megatron-LM'))
 
-# Defensive import
-try:
-    from megatron.inference.gpt.model_provider import _teacher_provider
-    IMPORT_SUCCESS = True
-except Exception as e:
-    print(f"Warning: Unable to import implementation code: {e}")
-    IMPORT_SUCCESS = False
+from megatron.inference.gpt.model_provider import _teacher_provider
 
 
 class TestTeacherProvider(unittest.TestCase):
@@ -56,7 +50,6 @@ class TestTeacherProvider(unittest.TestCase):
         self.mock_args.params_dtype = torch.float32
         self.mock_args.perform_initialization = True
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -134,7 +127,6 @@ class TestTeacherProvider(unittest.TestCase):
         # Verify: Teacher model is returned
         self.assertEqual(result, mock_model)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -183,7 +175,6 @@ class TestTeacherProvider(unittest.TestCase):
         # Verify: Original value is restored after loading
         self.assertEqual(self.mock_args.finetune, original_finetune)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -216,7 +207,6 @@ class TestTeacherProvider(unittest.TestCase):
         # Verify: non_homogeneous_layers is set to True
         self.assertTrue(mock_transformer_config.non_homogeneous_layers)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -259,7 +249,6 @@ class TestTeacherProvider(unittest.TestCase):
                 for key, value in model_kwargs.items():
                     self.assertEqual(call_kwargs[key], value)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -296,7 +285,6 @@ class TestTeacherProvider(unittest.TestCase):
         self.assertTrue(any('teacher' in arg.lower() and 'checkpoint' in arg.lower() 
                            for arg in call_args))
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -351,7 +339,6 @@ class TestTeacherProviderEdgeCases(unittest.TestCase):
         self.mock_args.finetune = False
         self.mock_args.export_kd_teacher_load = "/fake/path/to/teacher"
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')
@@ -384,7 +371,6 @@ class TestTeacherProviderEdgeCases(unittest.TestCase):
         # Verify: finetune is still True after loading
         self.assertTrue(self.mock_args.finetune)
     
-    @unittest.skipIf(not IMPORT_SUCCESS, "Implementation code import failed")
     @patch('megatron.inference.gpt.model_provider.load_modelopt_checkpoint')
     @patch('megatron.inference.gpt.model_provider.print_rank_0')
     @patch('megatron.inference.gpt.model_provider._add_load_convert_hooks')


### PR DESCRIPTION
## Summary
- Remove redundant `@unittest.skipIf(not IMPORT_SUCCESS, ...)` decorators from all test methods across 5 byteperf test files
- Replace defensive try/except import blocks with direct imports — the `sys.path` setup and `MinimalMock` already guarantee these imports succeed, so the guard was dead code that silently skipped tests

## Test plan
- [ ] Verify tests still pass with direct imports (mock setup ensures import success)
- [ ] Confirm no test is silently skipped due to removed `skipIf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)